### PR TITLE
Add email confirmation route

### DIFF
--- a/README.md
+++ b/README.md
@@ -71,3 +71,7 @@ Yes, you can!
 To connect a domain, navigate to Project > Settings > Domains and click Connect Domain.
 
 Read more here: [Setting up a custom domain](https://docs.lovable.dev/tips-tricks/custom-domain#step-by-step-guide)
+
+## Supabase Auth Configuration
+
+Add `https://YOUR_DOMAIN/confirm-email` to **Authentication > URL Configuration** in your Supabase project so confirmation emails redirect back to this app.

--- a/src/lib/supabase.ts
+++ b/src/lib/supabase.ts
@@ -1,0 +1,6 @@
+import { createClient } from '@supabase/supabase-js';
+
+const supabaseUrl = import.meta.env.VITE_SUPABASE_URL as string;
+const supabaseAnonKey = import.meta.env.VITE_SUPABASE_ANON_KEY as string;
+
+export const supabase = createClient(supabaseUrl, supabaseAnonKey);

--- a/src/routes/confirm-email.tsx
+++ b/src/routes/confirm-email.tsx
@@ -1,0 +1,42 @@
+import { useEffect, useState } from 'react';
+import { useLocation, useNavigate } from 'react-router-dom';
+import { supabase } from '../lib/supabase';
+
+export default function ConfirmEmail() {
+  const location = useLocation();
+  const navigate = useNavigate();
+  const [status, setStatus] = useState<'verifying' | 'success' | 'error'>('verifying');
+
+  useEffect(() => {
+    const params = new URLSearchParams(location.search);
+    const token = params.get('token');
+    if (!token) {
+      setStatus('error');
+      setTimeout(() => navigate('/login', { replace: true }), 2000);
+      return;
+    }
+
+    const verify = async () => {
+      const { error } = await supabase.auth.verifyOtp({ type: 'email', token });
+      if (error) {
+        setStatus('error');
+        setTimeout(() => navigate('/login', { replace: true }), 2000);
+      } else {
+        setStatus('success');
+        setTimeout(() => navigate('/', { replace: true }), 2000);
+      }
+    };
+
+    verify();
+  }, [location.search, navigate]);
+
+  if (status === 'verifying') {
+    return <p>Confirming your email...</p>;
+  }
+
+  if (status === 'error') {
+    return <p>Confirmation failed. Redirecting...</p>;
+  }
+
+  return <p>Email confirmed! Redirecting...</p>;
+}

--- a/tailwind.config.ts
+++ b/tailwind.config.ts
@@ -1,4 +1,5 @@
 import type { Config } from "tailwindcss";
+import tailwindcssAnimate from "tailwindcss-animate";
 
 export default {
 	darkMode: ["class"],
@@ -129,5 +130,5 @@ export default {
 			}
 		}
 	},
-	plugins: [require("tailwindcss-animate")],
+        plugins: [tailwindcssAnimate],
 } satisfies Config;


### PR DESCRIPTION
## Summary
- add Supabase client helper
- add confirm-email route that verifies token and redirects
- document Supabase redirect URL and fix Tailwind config import

## Testing
- `npm test` *(fails: Missing script "test")*
- `npm run lint`


------
https://chatgpt.com/codex/tasks/task_e_68b6f96d846c8321bdb900c1de8b39d1