### PR TITLE
feat: handle supabase email confirmation

### DIFF
--- a/src/App.tsx
+++ b/src/App.tsx
@@ -1,0 +1,12 @@
+import { Routes, Route } from 'react-router-dom';
+import ConfirmEmail from './pages/ConfirmEmail';
+
+export default function App() {
+  return (
+    <Routes>
+      <Route path="/confirm" element={<ConfirmEmail />} />
+      <Route path="*" element={<div>Home</div>} />
+    </Routes>
+  );
+}
+

--- a/src/lib/auth.ts
+++ b/src/lib/auth.ts
@@ -1,0 +1,20 @@
+import { supabase } from './supabaseClient';
+
+const redirectTo = `${window.location.origin}/confirm`;
+
+export async function signUp(email: string, password: string) {
+  return supabase.auth.signUp({
+    email,
+    password,
+    options: {
+      emailRedirectTo: redirectTo,
+    },
+  });
+}
+
+export async function resetPasswordForEmail(email: string) {
+  return supabase.auth.resetPasswordForEmail(email, {
+    redirectTo,
+  });
+}
+

--- a/src/lib/supabaseClient.ts
+++ b/src/lib/supabaseClient.ts
@@ -1,0 +1,7 @@
+import { createClient } from '@supabase/supabase-js';
+
+const supabaseUrl = import.meta.env.VITE_SUPABASE_URL as string;
+const supabaseAnonKey = import.meta.env.VITE_SUPABASE_PUBLISHABLE_KEY as string;
+
+export const supabase = createClient(supabaseUrl, supabaseAnonKey);
+

--- a/src/main.tsx
+++ b/src/main.tsx
@@ -1,0 +1,13 @@
+import React from 'react';
+import ReactDOM from 'react-dom/client';
+import { BrowserRouter } from 'react-router-dom';
+import App from './App';
+
+ReactDOM.createRoot(document.getElementById('root') as HTMLElement).render(
+  <React.StrictMode>
+    <BrowserRouter>
+      <App />
+    </BrowserRouter>
+  </React.StrictMode>
+);
+

--- a/src/pages/ConfirmEmail.tsx
+++ b/src/pages/ConfirmEmail.tsx
@@ -1,0 +1,31 @@
+import { useEffect, useState } from 'react';
+import { supabase } from '../lib/supabaseClient';
+
+export default function ConfirmEmail() {
+  const [status, setStatus] = useState('Confirming your email...');
+
+  useEffect(() => {
+    const params = new URLSearchParams(window.location.search);
+    const accessToken = params.get('access_token');
+    const refreshToken = params.get('refresh_token');
+    const type = params.get('type');
+
+    async function handleConfirmation() {
+      if (accessToken && refreshToken && type) {
+        const { error } = await supabase.auth.exchangeCodeForSession(window.location.href);
+        if (error) {
+          setStatus(`Error confirming email: ${error.message}`);
+        } else {
+          setStatus('Email confirmed!');
+        }
+      } else {
+        setStatus('Invalid confirmation link.');
+      }
+    }
+
+    handleConfirmation();
+  }, []);
+
+  return <div>{status}</div>;
+}
+

--- a/tailwind.config.ts
+++ b/tailwind.config.ts
@@ -1,4 +1,5 @@
 import type { Config } from "tailwindcss";
+import tailwindcssAnimate from "tailwindcss-animate";
 
 export default {
 	darkMode: ["class"],
@@ -129,5 +130,5 @@ export default {
 			}
 		}
 	},
-	plugins: [require("tailwindcss-animate")],
+        plugins: [tailwindcssAnimate],
 } satisfies Config;


### PR DESCRIPTION
## Summary
- add ConfirmEmail page to parse auth params and complete Supabase session
- include redirect options in signUp and resetPassword helpers
- switch Tailwind config to ESM plugin import

## Testing
- `npm run lint`
- `npm run build`


------
https://chatgpt.com/codex/tasks/task_e_68b6f98a0bb083218c8e4090c3af949c